### PR TITLE
Ignore Node.js dependency folders to keep PR branch clean

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -144,6 +144,8 @@ cifar*
 profile_default/
 ipython_config.py
 __pypackages__/
+node_modules/
+js/cleanlab-tlm/node_modules/
 
 
 # Data files
@@ -156,4 +158,3 @@ __pypackages__/
 **.rar
 **.zarr
 **.npy
-


### PR DESCRIPTION
### Motivation
- Prevent local Node dependency install artifacts from appearing as untracked noise in the working tree so the branch is easier to review and submit.

### Description
- Add `node_modules/` and `js/cleanlab-tlm/node_modules/` to `.gitignore` and commit the change to the current `work` branch.

### Testing
- Ran `git status --short` to confirm the working tree no longer showed the noisy untracked files and the command succeeded. 
- Inspected the change with `git diff -- .gitignore` which showed only the intended ignore additions and succeeded. 
- Committed the change with `git add .gitignore && git commit -m "Ignore Node.js dependency directories"` which succeeded. 
- Attempted `git fetch origin` to compare with upstream but the fetch failed due to a network/proxy error (`CONNECT tunnel failed, response 403`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c32a5662ac8329bc21e952a74cbeee)